### PR TITLE
Fixed links opening in Chrome

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@
 
 ---
 
+👉 [Click here to go to the original Checka11y.css project](https://github.com/jackdomleo7/Checka11y.css)
+
+---
+
 # Checka11y.css - browser extension
 
 **A CSS stylesheet to quickly highlight a11y concerns.**

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -25,7 +25,7 @@
             </svg>
             <span>Buy me a coffee</span>
         </a>
-        <a class="button button--github" href="https://github.com/jackdomleo7/Checka11y.css" rel="nofollow noopener" target="_blank">
+        <a class="button button--github" href="https://github.com/jackdomleo7/Checka11y.css-browser-extension" rel="nofollow noopener" target="_blank">
             <svg aria-hidden="true">
                 <use xlink:href="./sprite.svg#icon-github"></use>
             </svg>

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -18,14 +18,14 @@
     <small>Once applied, expect Checka11y.css to change the visual look and components. While this is unavoidable, Checka11y.css highlights HTML errors on the page.</small>
     <hr/>
     <div class="buttons">
-        <a class="button button--docs" href="https://checka11y.jackdomleo.dev">Read docs</a>
-        <a class="button button--coffee" href="https://www.buymeacoffee.com/jackdomleo7" rel="nofollow noopener">
+        <a class="button button--docs" href="https://checka11y.jackdomleo.dev" target="_blank">Read docs</a>
+        <a class="button button--coffee" href="https://www.buymeacoffee.com/jackdomleo7" rel="nofollow noopener" target="_blank">
             <svg aria-hidden="true">
                 <use xlink:href="./sprite.svg#icon-buymeacoffee"></use>
             </svg>
             <span>Buy me a coffee</span>
         </a>
-        <a class="button button--github" href="https://github.com/jackdomleo7/Checka11y.css" rel="nofollow noopener">
+        <a class="button button--github" href="https://github.com/jackdomleo7/Checka11y.css" rel="nofollow noopener" target="_blank">
             <svg aria-hidden="true">
                 <use xlink:href="./sprite.svg#icon-github"></use>
             </svg>


### PR DESCRIPTION
- Resolves #1
- Added `target="_blank"` to links in the popup
- Changed GitHub link to browser extension repo as opposed to Checka11y.css repo