### PR TITLE
Add link to feature codes md file in Checka11y.css repo

### DIFF
--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -19,6 +19,7 @@
     <hr/>
     <div class="buttons">
         <a class="button button--docs" href="https://checka11y.jackdomleo.dev" target="_blank">Read docs</a>
+        <a class="button button--codes" href="https://github.com/jackdomleo7/Checka11y.css/blob/master/codes.md" target="_blank">Feature codes</a>
         <a class="button button--coffee" href="https://www.buymeacoffee.com/jackdomleo7" rel="nofollow noopener" target="_blank">
             <svg aria-hidden="true">
                 <use xlink:href="./sprite.svg#icon-buymeacoffee"></use>

--- a/src/popup/style.css
+++ b/src/popup/style.css
@@ -119,7 +119,8 @@ hr {
 .buttons {
   display: grid;
   gap: 0.5rem;
-  grid-template-areas: 'docs coffee'
+  grid-template-areas: 'coffee coffee'
+                       'docs codes'
                        'github github';
 }
 
@@ -148,6 +149,10 @@ hr {
 
 .button--docs {
   grid-area: docs;
+}
+
+.button--codes {
+  grid-area: codes;
 }
 
 .button--coffee {


### PR DESCRIPTION
Added a link to the [Checka11y.css codes.md](https://github.com/jackdomleo7/Checka11y.css/blob/master/codes.md) file, since this was a new feature in [v1.3.0 of Checka11y.css](https://github.com/jackdomleo7/Checka11y.css/releases/tag/v1.3.0).

![image](https://user-images.githubusercontent.com/43371432/106755738-625d3c80-6626-11eb-88c8-f1433c41fbe1.png)
![image](https://user-images.githubusercontent.com/43371432/106755681-4d80a900-6626-11eb-855d-415c19ecc26b.png)