### PR TITLE
Fix badge always being shown

### DIFF
--- a/src/popup/script.js
+++ b/src/popup/script.js
@@ -14,7 +14,7 @@ window.addEventListener('load', () => {
 
   const toggleStylesheet = () => {
     browser.tabs.query({active: true, currentWindow: true}, tabs => {
-        browser.browserAction.setBadgeText({text: displayStylesheet ? 'On' : '', tabId: tabs[0].id});
+        browser.browserAction.setBadgeText({text: displayStylesheetToggle.checked ? 'On' : '', tabId: tabs[0].id});
         browser.tabs.sendMessage(tabs[0].id, {type: 'toggleStylesheet', displayStylesheet: displayStylesheetToggle.checked, disableWarnings: disableWarningsToggle.checked});
     });
   }


### PR DESCRIPTION
- There was a bug in v1.2.0 where the "On" badge was always being displayed

![Uploading badge-always-shown.gif…]()

This has now been resolved.
