### PR TITLE
Migrate from Manifest v2 to Manifest v3

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
   "homepage_url": "https://checka11y.jackdomleo.dev",
   "author": "Jack Domleo",
   "manifest_version": 2,
-  "browser_action": {
+  "action": {
     "default_title": "Checka11y.css",
     "default_popup": "src/popup/popup.html",
     "default_icon": {

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
   "description": "The browser extension for Checka11y.css - a CSS-only accessibility checker",
   "homepage_url": "https://checka11y.jackdomleo.dev",
   "author": "Jack Domleo",
-  "manifest_version": 2,
+  "manifest_version": 3,
   "action": {
     "default_title": "Checka11y.css",
     "default_popup": "src/popup/popup.html",

--- a/src/popup/script.js
+++ b/src/popup/script.js
@@ -14,7 +14,7 @@ window.addEventListener('load', () => {
 
   const toggleStylesheet = () => {
     browser.tabs.query({active: true, currentWindow: true}, tabs => {
-        browser.browserAction.setBadgeText({text: displayStylesheetToggle.checked ? 'On' : '', tabId: tabs[0].id});
+        browser.action.setBadgeText({text: displayStylesheetToggle.checked ? 'On' : '', tabId: tabs[0].id});
         browser.tabs.sendMessage(tabs[0].id, {type: 'toggleStylesheet', displayStylesheet: displayStylesheetToggle.checked, disableWarnings: disableWarningsToggle.checked});
     });
   }
@@ -25,7 +25,7 @@ window.addEventListener('load', () => {
       displayStylesheetToggle.checked = stylesheetHref != null;
       displayStylesheetToggle.dispatchEvent(new Event('input'));
       disableWarningsToggle.checked = stylesheetHref.includes('checka11y-errors.css');
-      browser.browserAction.setBadgeText({text: stylesheetHref ? 'On' : '', tabId: tabs[0].id});
+      browser.action.setBadgeText({text: stylesheetHref ? 'On' : '', tabId: tabs[0].id});
     });
   });
 


### PR DESCRIPTION
Fixes #11 

Proposed Changes:

- Change `manifest_version` from 2 to 3 in the manifest
- Replace `browser_action` and/or `page_action` attributes with `action` as they are unified into a single `action` property in MV3
- Replace `chrome.browserAction` and/or `chrome.pageAction` with `chrome.action` as these are also unified into a single API in MV3
- Todo: Double check the MV3 migration checklist and the [Firefox MV3 update](https://blog.mozilla.org/addons/2021/05/27/manifest-v3-update/) to ensure nothing is missed. Otherwise, this might be able to stay as a "single" extension which serves both browsers like you've setup.

References:
MV3 Migration Checklist - https://developer.chrome.com/docs/extensions/mv3/mv3-migration-checklist/
Firefox MV3 Update - https://blog.mozilla.org/addons/2021/05/27/manifest-v3-update/